### PR TITLE
docs: add comprehensive README usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,99 @@
 > [![Side Effect][side-effect-image]][bundle-phobia-url]
 > [![License][license-image]][license-url]
 
+## Installation
+
+```bash
+npm i -D svgc-loader svgo
+# or
+pnpm add -D svgc-loader svgo
+# or
+yarn add -D svgc-loader svgo
+```
+
+> `svgc-loader` requires Node.js `>=16`.
+
+## Usage
+
+### Webpack
+
+```js
+// webpack.config.js
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.svg$/i,
+        issuer: /\.[jt]sx?$/i,
+        use: [
+          {
+            loader: 'svgc-loader',
+            options: {
+              target: 'react-dom',
+              plugins: ['preset-default']
+            }
+          }
+        ]
+      }
+    ]
+  }
+};
+```
+
+### Rspack
+
+```js
+// rspack.config.js
+export default {
+  module: {
+    rules: [
+      {
+        test: /\.svg$/i,
+        issuer: /\.[jt]sx?$/i,
+        use: [
+          {
+            loader: 'svgc-loader/rspack',
+            options: {
+              target: 'react-dom',
+              plugins: ['preset-default']
+            }
+          }
+        ]
+      }
+    ]
+  }
+};
+```
+
+### Import SVG as Component
+
+```tsx
+import Logo from './logo.svg';
+
+export function App() {
+  return <Logo width={120} height={120} aria-label="logo" />;
+}
+```
+
+## Loader Options
+
+All options are compatible with SVGO v4 and support extra component-conversion options:
+
+- `configFile?: string | false` - path to SVGO config file, or `false` to disable config-file loading.
+- `target?: 'preact' | 'react-dom' | 'react-native'` - output runtime target.
+- `svgProps?: Record<string, unknown>` - extra props merged into the generated `<svg />`.
+- `template?: (options) => string` - custom code template for component generation.
+- `multipass?: boolean` - run SVGO in multipass mode.
+- `floatPrecision?: number` - precision for SVGO plugins that support it.
+- `plugins?: Array<string | { name: string; params?: object } | { name: string; fn: Function }>` - SVGO plugins.
+- `js2svg?: object` - SVGO js2svg output formatting options.
+
+## Notes
+
+- Default `target` is `react-dom`.
+- Default SVGO plugin list is `['preset-default']`.
+- You can provide your own `template` to fully control emitted component code.
+
 [npm-image]: https://img.shields.io/npm/v/svgc-loader?style=flat-square
 [npm-url]: https://www.npmjs.org/package/svgc-loader
 [download-image]: https://img.shields.io/npm/dm/svgc-loader?style=flat-square


### PR DESCRIPTION
### Motivation
- Fill the README placeholder with a complete usage guide so consumers can quickly install and use the loader. 
- Provide concrete configuration examples for both `webpack` and `rspack` to reduce onboarding friction. 
- Document loader options and defaults to make customization and SVGO integration clear.

### Description
- Added an `Installation` section with `npm`, `pnpm`, and `yarn` examples and a Node.js version note. 
- Added `Usage` examples for `webpack` (using `svgc-loader`) and `rspack` (using `svgc-loader/rspack`) showing rule configurations. 
- Added an `Import SVG as Component` example and a `Loader Options` section describing `configFile`, `target`, `svgProps`, `template`, `multipass`, `floatPrecision`, `plugins`, and `js2svg`. 
- Added a `Notes` section that states the default `target` and default SVGO plugin list and points out template customization; README was formatted with Prettier.

### Testing
- Ran `pnpm -s prettier --check README.md` which succeeded. 
- No additional automated tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccce0ad43c8333938c97074881fa47)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added installation guide with Node.js version requirements
  * Included usage examples for Webpack and Rspack loaders
  * Documented SVG-to-React component import process
  * Added detailed loader options reference including SVGO compatibility
  * Clarified configuration defaults and custom template usage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->